### PR TITLE
Remove the simple key. Just put configuration under data.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,21 @@
 language: node_js
 sudo: false
-before_install:
-  - "export CODECLIMATE_REPO_TOKEN=897166616c6cd6f7cebd180f6ef89c02b1a3f483ba91690159bde9534af7fc19"
+addons:
+  code_climate:
+    repo_token: 897166616c6cd6f7cebd180f6ef89c02b1a3f483ba91690159bde9534af7fc19
 install:
   - "npm install -g npm@latest"
   - "npm install grunt-cli codeclimate-test-reporter -g"
   - "npm install"
 script:
   - "grunt ci"
+after_script:
+  - "codeclimate-test-reporter < coverage/lcov.info"
 node_js:
   - "4"
   - "5"
   - "6"
+  - "7"
 cache:
   directories:
     - 'node_modules'

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,7 +6,6 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-travis-matrix');
   grunt.loadNpmTasks('grunt-simple-istanbul');
   grunt.loadNpmTasks('grunt-open');
-  grunt.loadNpmTasks('grunt-shell');
   grunt.loadTasks('test/fixtures/tasks');
 
   var onComplete = function(err, stdout, done) {
@@ -53,11 +52,8 @@ module.exports = function(grunt) {
         test: function() {
           return /^v4/.test(process.version);
         },
-        tasks: ['istanbul:cover', 'shell:codeclimate']
+        tasks: ['istanbul:cover']
       }
-    },
-    shell: {
-      codeclimate: 'codeclimate-test-reporter < coverage/lcov.info'
     },
     watch: {
       tests: {
@@ -90,126 +86,82 @@ module.exports = function(grunt) {
           negated: false,
           b: 'quux',
           c: true,
-          'author=': 'Andrew',
-          simple: {
-            onComplete: onComplete
-          }
-        }
+          'author=': 'Andrew'
+        },
+        onComplete: onComplete
       },
       env: {
-        options: {
-          simple: {
-            onComplete: onComplete,
-            env: {
-              FOO: 'BAR'
-            }
-          }
+        onComplete: onComplete,
+        env: {
+          FOO: 'BAR'
         }
       },
       cwd: {
         options: {
-          simple: {
-            onComplete: onComplete,
-            cwd: __dirname + '/test'
-          },
           cwd: true
-        }
+        },
+        onComplete: onComplete,
+        cwd: __dirname + '/test'
       },
       force: {
         options: {
-          simple: {
-            onComplete: onComplete,
-            force: true
-          },
           fail: true
-        }
+        },
+        onComplete: onComplete,
+        force: true
       },
       cmd: {
-        options: {
-          simple: {
-            onComplete: onComplete,
-            cmd: 'not-cmd'
-          }
-        }
+        onComplete: onComplete,
+        cmd: 'not-cmd'
       },
       args: {
-        options: {
-          simple: {
-            onComplete: onComplete,
-            args: ['jingle', 'bells']
-          }
-        }
+        onComplete: onComplete,
+        args: ['jingle', 'bells']
       },
       raw: {
-        options: {
-          simple: {
-            onComplete: onComplete,
-            rawArgs: '-- $% "hello" '
-          }
-        }
+        onComplete: onComplete,
+        rawArgs: '-- $% "hello" '
       },
       debug: {
-        options: {
-          simple: {
-            onComplete: onComplete,
-            debug: true
-          }
-        }
+        onComplete: onComplete,
+        debug: true
       },
       stdout: {
-        options: {
-          simple: {
-            onComplete: onComplete,
-            debug: {
-              stdout: 'Hey banana'
-            }
-          }
+        onComplete: onComplete,
+        debug: {
+          stdout: 'Hey banana'
         }
       },
       dynamic: {
         options: {
-          simple: {
-            onComplete: onComplete
-          },
           foo: '{{ foo }}'
-        }
+        },
+        onComplete: onComplete
       },
       'dynamic-nested': {
         options: {
-          simple: {
-            onComplete: onComplete,
-            args: ['{{ hello.world }}']
-          },
           foo: '{{ foo }}'
-        }
+        },
+        onComplete: onComplete,
+        args: ['{{ hello.world }}']
       }
     },
     proxy: {},
     'opts-test': {
       custom: {
-        options: {
-          simple: {
-            onComplete: onComplete,
-            foo: 'Ned'
-          }
-        }
+        onComplete: onComplete,
+        foo: 'Ned'
       },
       dash: {
         options: {
-          simple: {
-            onComplete: onComplete
-          },
           foo: 'bar'
-        }
+        },
+        onComplete: onComplete
       }
     },
     'callback-test': {
       cb: {
-        options: {
-          simple: {
-            onComplete: onComplete
-          }
-        }
+        onComplete: onComplete
       }
     }
   });

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ This will run `blerg murica -a foo -a bar --fruit banana --fruit kiwi`.
 
 ## Simple cli options
 
-There are also some library specific options. Options about how simple cli itself behaves are placed under the `simple` key.
+There are also some library specific options. Options about how simple cli itself behaves are placed at the top level of a task target.
 
 #### quiet
 
@@ -177,10 +177,9 @@ grunt.initConfig({
   blerg: {
     lollipop: {
       options: {
-        simple: {
-          quiet: true
-        }
-      }
+        foo: 'bar'
+      },
+      quiet: true
     }
   }
 });
@@ -195,18 +194,17 @@ grunt.initConfig({
   blerg: {
     hoodoo: {
       options: {
-        simple: {
-          env: {
-            FOO: 'bar'
-          }
-        }
+        foo: 'bar'
+      },
+      env: {
+        BANANA: 'yellow'
       }
     }
   }
 });
 ```
 
-Like running `FOO=bar blerg hoodoo`.
+Like running `BANANA=yellow blerg hoodoo --foo bar`.
 
 #### cwd
 
@@ -217,16 +215,15 @@ grunt.initConfig({
   blerg: {
     jackwagon: {
       options: {
-        simple: {
-          cwd: './test'
-        }
-      }
+        foo: 'bar'
+      },
+      cwd: './test'
     }
   }
 });
 ```
 
-Runs `blerg jackwagon`, but in the `./test` directory.
+Runs `blerg jackwagon --foo bar`, but in the `./test` directory.
 
 #### force
 
@@ -236,11 +233,7 @@ If the task fails, don't halt the entire task chain. Note that this is different
 grunt.initConfig({
   blerg: {
     muncher: {
-      options: {
-        simple: {
-          force: true
-        }
-      }
+      force: true
     }
   }
 });
@@ -254,16 +247,12 @@ A callback to handle the stdout and stderr streams. `simple-cli` aggregates the 
 grunt.initConfig({
   blerg: {
     portmanteau: {
-      options: {
-        simple: {
-          onComplete: function(err, stdout, callback) {
-            if (err) {
-              grunt.fail.fatal(err.message, err.code);
-            } else {
-              grunt.config.set('portmanteau', stdout);
-              callback();
-            }
-          });
+      onComplete: function(err, stdout, callback) {
+        if (err) {
+          grunt.fail.fatal(err.message, err.code);
+        } else {
+          grunt.config.set('portmanteau', stdout);
+          callback();
         }
       }
     }
@@ -280,20 +269,12 @@ grunt.initConfig({
   // Using git as a real example
   git: {
     pushOrigin: {
-      options: {
-        simple: {
-          cmd: 'push',
-          args: ['origin', 'master']
-        }
-      }
+      cmd: 'push',
+      args: ['origin', 'master']
     },
     pushHeroku: {
-      options: {
-        simple: {
-          cmd: 'push',
-          args: 'heroku master'
-        }
-      }
+      cmd: 'push',
+      args: 'heroku master'
     }
   }
 });
@@ -307,18 +288,14 @@ Additional, non-flag arguments to pass to the executable. These can be passed as
 
 #### rawArgs
 
-`rawArgs` is a catch all for any arguments to the executable that can't be handled (for whatever reason) with the options above (e.g. the path arguments in some git commands: `git checkout master -- config/production.json`). Anything in `rawArgs` will be concatenated to the end of all the normal args.
+`rawArgs` is a catch all for any arguments to the executable that can't be handled (for whatever reason) with the options above (e.g. the path arguments in some git commands: `git checkout master -- config/production.json`). Anything in `rawArgs` will be concatenated to the end of all the normal args. It can be a string or an array of strings.
 
 ```js
 grunt.initConfig({
   git: {
     checkout: {
-      options: {
-        simple: {
-          args: ['master'],
-          rawArgs: '-- config/production.json'
-        }
-      }
+      args: ['master'],
+      rawArgs: '-- config/production.json'
     }
   }
 });
@@ -332,29 +309,21 @@ Similar to `--dry-run` in many executables. This will log the command that will 
 grunt.initConfig({
   blerg: {
     'waffle-iron': {
-      options: {
-        simple: {
-          // Invoked with default fake stderr/stdout
-          onComplete: function(err, stdout, callback) {
-            console.log(err.message, stdout);
-            callback();
-          },
-          debug: true
-        }
-      }
+      // Invoked with default fake stderr/stdout
+      onComplete: function(err, stdout, callback) {
+        console.log(err.message, stdout);
+        callback();
+      },
+      debug: true
     },
     'wilty-salad': {
-      options: {
-        simple: {
-          onComplete: function(err, stdout, callback) {
-            console.log(err.message, stdout); // Logs 'foo bar'
-            callback();
-          },
-          debug: {
-            stderr: 'foo',
-            stdout: 'bar'
-          }
-        }
+      onComplete: function(err, stdout, callback) {
+        console.log(err.message, stdout); // Logs 'foo bar'
+        callback();
+      },
+      debug: {
+        stderr: 'foo',
+        stdout: 'bar'
       }
     }
   }
@@ -375,14 +344,10 @@ Supply the value when you call the task itself.
 grunt.initConfig({
   git: {
     push: {
-      options: {
-        simple: {
-          // You can also do this as a string, but note that simple-cli splits
-          // string args on space, so you wouldn't be able to put space INSIDE
-          // the interpolation. You'd have to say args: '{{remote}} master'
-          args: ['{{ remote }}', 'master']
-        }
-      }
+      // You can also do this as a string, but note that simple-cli splits
+      // string args on space, so you wouldn't be able to put space INSIDE
+      // the interpolation. You'd have to say args: '{{remote}} master'
+      args: ['{{ remote }}', 'master']
     }
   }
 });
@@ -420,13 +385,15 @@ For very simple tasks, you can define the task body as an array or string, rathe
 grunt.initConfig({
   git: {
     // will invoke "git push origin master"
-    origin: ['push', 'origin', 'master'],
+    push: ['origin', 'master'],
 
     // will invoke "git pull upstream master"
-    upstream: 'pull upstream master'
+    pull: 'upstream master'
   }
 });
 ```
+
+Note that this _only_ works if the target name is the command you want to run. If you need, for example, multiple `push` targets, you'll have to use the longer syntax with `cmd` and `args`.
 
 ## Invoking simple cli
 
@@ -525,7 +492,7 @@ Other properties available on the `this` object within this method are:
 * this.context -> the grunt task context
 * this.cmd -> the command executed via child process
 * this.options -> the task options
-* this.config -> the task configuration (i.e. `options.simple` under the task options)
+* this.config -> the task configuration (e.g. `cmd`, `args`, `rawArgs`, `env`, etc.)
 * this.customOptions -> custom options parsers provided by your wrapper
 * this.env -> environment variables to supply to the child process
 * this.target -> the command to run on the executable (e.g. "commit" in "git commit")
@@ -536,7 +503,7 @@ Other properties available on the `this` object within this method are:
 
 Optional.
 
-The options object is actually just a way to extend the `simple-cli` API. Keys in the object are options allowed under `options.simple` and the values are the handlers for those options. So if you need more cowbell in your cli wrapper, you can do that:
+The options object is actually just a way to extend the `simple-cli` API. Keys in the object are options allowed as part of the task configuration data and the values are the handlers for those options. So if you need more cowbell in your cli wrapper, you can do that:
 
 ```js
 var cli = require('simple-cil');
@@ -545,7 +512,19 @@ module.exports = cli({
   task: 'foo',
   options: {
     moreCowbell: function(val, cb) {
-      // I've got a fever...
+      // val is the user-assigned config value of "moreCowbell," e.g.
+      // grunt.initConfig({
+      //   foo: {
+      //     bar: {
+      //       options: {
+      //         moreCowbell: 'blah'
+      //       }
+      //     }
+      //   }
+      // });
+
+      // Now "this.target" is "halb" . . . probably not that useful, but it's just an example
+      this.target = val.split('').reverse().join('');
       cb();
     }
   }

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -14,50 +14,41 @@ var Builder = module.exports = function Builder (options, context, grunt) {
   this.singleDash = options.singleDash;
   this.done = context.async();
   this.callback = options.callback ? options.callback.bind(this) : this.done;
-  this.options = context.options({
-    simple: {
-      args: [],
-      rawArgs: [],
-      env: {}
-    }
-  });
-  this.config = this.options.simple;
-  delete this.options.simple;
-  this.debugOn = grunt.option('debug') || this.config.debug;
+  this.options = context.options({});
   this.context = context;
+  this.setConfig(context);
+  this.debugOn = grunt.option('debug') || this.config.debug;
   this.grunt = grunt;
   this.customOptions = options.options;
   this.env = extend({}, process.env, this.config.env);
 };
 
-Builder.prototype.configure = function() {
-  var data = this.context.data;
+Builder.prototype.setConfig = function(context) {
+  var data = context.data;
 
   // If data is not an object, then the short form is being used, where
   // the entire grunt target is just a string or array that makes up
   // the command to run.
   if (!_.isPlainObject(data)) {
-
-    // Standardize to an array
-    if (typeof data === 'string') {
-      data = data.split(' ');
-    }
-
-    // The first arg is the command and the rest are options
-    this.config.cmd = data.shift();
-    this.config.args = data;
+    this.config = {
+      args: data,
+      rawArgs: [],
+      env: {}
+    };
+    this.target = _.kebabCase(context.target);
+  } else {
+    this.config = _.defaults(_.omit(data, 'options'), {
+      cmd: null,
+      args: [],
+      rawArgs: [],
+      env: {}
+    });
+    this.target = this.config.cmd || _.kebabCase(context.target);
   }
 
-  // Target equates to the binary command, e.g. "commit" in "git commit"
-  this.target = this.config.cmd || _.kebabCase(this.context.target);
-
-  // If args is a string, make an array. This will only happen if args
-  // are specified on the "simple" property in the task configuration.
   if (typeof this.config.args === 'string') {
     this.config.args = this.config.args.split(' ');
   }
-
-  return this;
 };
 
 Builder.prototype.buildOptions = function() {

--- a/lib/simple-cli.js
+++ b/lib/simple-cli.js
@@ -18,7 +18,7 @@ module.exports = function(options) {
       var builder = new Builder(options, this, grunt);
 
       // Handle all manner of options
-      builder.configure().buildOptions().getDynamicValues(function() {
+      builder.buildOptions().getDynamicValues(function() {
 
         // Loop over custom options and supply them to the consumer
         async.each(_.keys(options.options), builder.handleCustomOption.bind(builder), function(err) {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "grunt-contrib-watch": "^1.0.0",
     "grunt-mocha-test": "^0.12.7",
     "grunt-open": "^0.2.3",
-    "grunt-shell": "^1.3.0",
     "grunt-simple-istanbul": "^1.0.1",
     "grunt-travis-matrix": "^1.0.0",
     "indeed": "^1.1.0",

--- a/test/simple-cli.coffee
+++ b/test/simple-cli.coffee
@@ -1,8 +1,7 @@
 describe 'simple cli', ->
   Given -> @Builder = sinon.stub()
   Given -> @Builder.returns
-  Given -> @builder = spyObj 'configure', 'buildOptions', 'getDynamicValues', 'spawn', 'handleCustomOption', 'debug'
-  Given -> @builder.configure.returns @builder
+  Given -> @builder = spyObj 'buildOptions', 'getDynamicValues', 'spawn', 'handleCustomOption', 'debug'
   Given -> @builder.buildOptions.returns @builder
   Given -> @Builder.returns @builder
   Given -> @builder.getDynamicValues.callsArg(0)


### PR DESCRIPTION
The depth of nesting when you needed to set simple-cli options was just getting out of hand. Now instead of

```
grunt.initConfig({
  task: {
    target: {
      options: {
        simple: {
          env: {
            foo: 'bar'
          }
        }
      }
    }
  }
});
```

which is just absurdly nested, and especially unuseful and annoying when you have no options for the executable itself, you can just do

```
grunt.initConfig({
  task: {
    target: {
      options: {
        // still put executable options here
      },
      env: {
        foo: 'bar'
      }
    }
  }
});
```
