### PR TITLE
Fix path delimiter on win32

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -24,8 +24,9 @@ class Builder {
     // Using require.resolve allows the executable to be installed by the wrapper as a
     // dependency or by the end user (in which the wrapper is probably specifying a
     // peerDependency)
-    let localPath = `${resolve(this.cmd).split(this.cmd)[0]}.bin`;
-    let path = [ localPath, process.env.PATH ].join(':');
+    const localPath = `${resolve(this.cmd).split(this.cmd)[0]}.bin`;
+    const pathDelimiter = process.platform === 'win32' ? ';' : ':';
+    const path = [ localPath, process.env.PATH ].join(pathDelimiter);
     this.env = Object.assign({}, process.env, this.config.env, { PATH: path });
     this.args = this.buildArgs();
   }


### PR DESCRIPTION
On windows the path needs to be constructed using `;` as delimiters. This PR adds a simple switch to fix that.

Motivation: I was trying to use https://github.com/tandrewnichols/grunt-simple-nyc on windows, but it didn't find nyc. Turned out the path was wrong.